### PR TITLE
use early returns instead of passthrough requests

### DIFF
--- a/netlify/edge-functions/crawler-detector.ts
+++ b/netlify/edge-functions/crawler-detector.ts
@@ -34,14 +34,14 @@ const CRAWLER_USER_AGENTS = [
 
 const isCrawler = (userAgent: string): boolean => {
   if (!userAgent) return false;
-  
+
   const ua = userAgent.toLowerCase();
   return CRAWLER_USER_AGENTS.some(bot => ua.includes(bot));
 };
 
 const isPrerenderRequest = (url: URL): boolean => {
   // Check for common prerender query parameters
-  return url.searchParams.has('_escaped_fragment_') || 
+  return url.searchParams.has('_escaped_fragment_') ||
          url.searchParams.has('prerender') ||
          url.hash === '#!';
 };
@@ -49,24 +49,24 @@ const isPrerenderRequest = (url: URL): boolean => {
 export default async (req: Request, context: Context) => {
   const url = new URL(req.url);
   const userAgent = req.headers.get('user-agent') || '';
-  
+
   // Skip processing for non-HTML requests
   const acceptHeader = req.headers.get('accept') || '';
   if (!acceptHeader.includes('text/html')) {
-    return context.next();
+    return
   }
-  
+
   // Skip for API routes, assets, and static files
-  if (url.pathname.startsWith('/api/') || 
+  if (url.pathname.startsWith('/api/') ||
       url.pathname.startsWith('/_next/') ||
       url.pathname.startsWith('/static/') ||
       url.pathname.includes('.') && !url.pathname.endsWith('.html')) {
-    return context.next();
+    return
   }
-  
+
   // Check if this is a crawler or prerender request
   const shouldPrerender = isCrawler(userAgent) || isPrerenderRequest(url);
-  
+
   if (shouldPrerender) {
     // Construct the prerender URL
     const prerenderUrl = new URL('/api/prerender', req.url);
@@ -91,9 +91,9 @@ export default async (req: Request, context: Context) => {
       return context.next();
     }
   }
-  
+
   // For regular users, serve the normal page
-  return context.next();
+  return
 };
 
 export const config: Config = {

--- a/netlify/edge-functions/crawler-detector.ts
+++ b/netlify/edge-functions/crawler-detector.ts
@@ -88,7 +88,7 @@ export default async (req: Request, context: Context) => {
     } catch (error) {
       console.error('Error calling prerender service:', error);
       // Fall back to normal response if prerender fails
-      return context.next();
+      return
     }
   }
 


### PR DESCRIPTION
https://answers.netlify.com/t/tips-for-terminating-a-request-with-edge-functions/88471

Minor change to allow for early return from the function instead of waiting for the response in the edge function itself. 