### PR TITLE
Fix browser instance lifecycle management in serverless environment

### DIFF
--- a/netlify/functions/prerender.mts
+++ b/netlify/functions/prerender.mts
@@ -12,6 +12,35 @@ declare global {
 let browser: any = null;
 
 async function getBrowser() {
+  if (browser) {
+    try {
+      // Multi-layer validation to ensure browser is still connected and responsive
+      if (!browser.isConnected()) {
+        throw new Error('Browser disconnected');
+      }
+      
+      // Test actual CDP communication with timeout to detect stale connections
+      const pages = await Promise.race([
+        browser.pages(),
+        new Promise((_, reject) => 
+          setTimeout(() => reject(new Error('Health check timeout')), 2000)
+        )
+      ]);
+      
+      console.log('Browser health check passed, reusing existing instance');
+      return browser;
+    } catch (error) {
+      console.log('Browser health check failed, recreating:', error.message);
+      try {
+        await browser.close();
+      } catch (closeError) {
+        // Ignore close errors for dead connections
+        console.log('Failed to close dead browser connection:', closeError.message);
+      }
+      browser = null;
+    }
+  }
+  
   if (!browser) {
     // Check if running in Netlify/AWS Lambda environment
     const isProduction = !process.env.NETLIFY_DEV;
@@ -36,6 +65,8 @@ async function getBrowser() {
         args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage']
       });
     }
+    
+    console.log('New browser instance created successfully');
   }
   
   return browser;


### PR DESCRIPTION
## Summary
- Fix "Protocol error: Connection closed" and "Navigating frame was detached" errors in production
- Add comprehensive browser health check to `getBrowser()` function before reusing instances
- Implement connection validation via `isConnected()` and CDP communication test with 2-second timeout
- Add graceful recovery for dead browser connections

## Test plan
- [ ] Deploy to staging environment and test with crawler user agents
- [ ] Verify browser instances are properly reused when healthy
- [ ] Confirm new instances are created when connections are stale
- [ ] Monitor logs for improved error handling and connection recovery

🤖 Generated with [Claude Code](https://claude.ai/code)