### PR TITLE
Skip third-party & visual resources by default; trigger browser cleanup

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -7,6 +7,7 @@
       "npm:@netlify/functions@^4.1.4": "npm:@netlify/functions@4.1.7",
       "npm:@netlify/vite-plugin@^2.2.2": "npm:@netlify/vite-plugin@2.3.2_vite@6.3.5__picomatch@4.0.2",
       "npm:@sparticuz/chromium@^133.0.0": "npm:@sparticuz/chromium@133.0.0",
+      "npm:@types/psl@^1.1.3": "npm:@types/psl@1.1.3",
       "npm:@types/react-dom@^19.1.2": "npm:@types/react-dom@19.1.6_@types+react@19.1.8",
       "npm:@types/react@^19.1.2": "npm:@types/react@19.1.8",
       "npm:@vitejs/plugin-react@^4.4.1": "npm:@vitejs/plugin-react@4.6.0_vite@6.3.5__picomatch@4.0.2_@babel+core@7.27.4",
@@ -14,6 +15,7 @@
       "npm:eslint-plugin-react-refresh@^0.4.19": "npm:eslint-plugin-react-refresh@0.4.20_eslint@9.29.0",
       "npm:eslint@^9.25.0": "npm:eslint@9.29.0",
       "npm:globals@^16.0.0": "npm:globals@16.2.0",
+      "npm:psl@^1.15.0": "npm:psl@1.15.0",
       "npm:puppeteer-core@^24.10.0": "npm:puppeteer-core@24.10.2_devtools-protocol@0.0.1452169",
       "npm:puppeteer@^24.10.0": "npm:puppeteer@24.10.2_devtools-protocol@0.0.1452169_typescript@5.8.3",
       "npm:react-dom@^19.1.0": "npm:react-dom@19.1.0_react@19.1.0",
@@ -1091,6 +1093,10 @@
       },
       "@types/normalize-package-data@2.4.4": {
         "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+        "dependencies": {}
+      },
+      "@types/psl@1.1.3": {
+        "integrity": "sha512-Iu174JHfLd7i/XkXY6VDrqSlPvTDQOtQI7wNAXKKOAADJ9TduRLkNdMgjGiMxSttUIZnomv81JAbAbC0DhggxA==",
         "dependencies": {}
       },
       "@types/react-dom@19.1.6_@types+react@19.1.8": {
@@ -3555,6 +3561,12 @@
         "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
         "dependencies": {}
       },
+      "psl@1.15.0": {
+        "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+        "dependencies": {
+          "punycode": "punycode@2.3.1"
+        }
+      },
       "pump@3.0.3": {
         "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
         "dependencies": {
@@ -4447,6 +4459,7 @@
         "npm:@netlify/functions@^4.1.4",
         "npm:@netlify/vite-plugin@^2.2.2",
         "npm:@sparticuz/chromium@^133.0.0",
+        "npm:@types/psl@^1.1.3",
         "npm:@types/react-dom@^19.1.2",
         "npm:@types/react@^19.1.2",
         "npm:@vitejs/plugin-react@^4.4.1",
@@ -4454,6 +4467,7 @@
         "npm:eslint-plugin-react-refresh@^0.4.19",
         "npm:eslint@^9.25.0",
         "npm:globals@^16.0.0",
+        "npm:psl@^1.15.0",
         "npm:puppeteer-core@^24.10.0",
         "npm:puppeteer@^24.10.0",
         "npm:react-dom@^19.1.0",

--- a/netlify/functions/prerender.mts
+++ b/netlify/functions/prerender.mts
@@ -330,16 +330,18 @@ export default async (req: Request, context: Context) => {
     // Single success log line with all important details
     console.log(`PRERENDER SUCCESS: ${targetUrl} | ${renderTime}ms total (${getBrowserTime}ms get browser, ${navigationTime}ms nav, ${totalWaitTime}ms wait) | ${statusCode} status | ${htmlSize}B HTML | ${blockedCount} requests blocked | IP=${clientIP}`);
     
-    // In resource-constrained environments, creating a new page can hang for a while until the 
-    // browser is available again. Therefore, spending that time now (if needed) but without blocking 
-    // the response.
+    /* 
+    In resource-constrained environments, creating new pages often hangs for a while
+    (probably due to actually forcing a resource release which does not occur on page.close()).
+    To avoid making the next invocation of this function instance slower, this cleanup is triggered asynchrnously now.
+    */
     const cleanup = async () => {
       const cleanupStart = Date.now();
       const page = await browserInstance.newPage();
       await page.close();
       console.log(`Async resource cleanup done in ${Date.now() - cleanupStart}ms`);
     }
-    context.waitUntil(cleanup());
+    context.waitUntil(cleanup()); // Does not block returning the response below
 
     return new Response(html, {
       status: statusCode,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@netlify/functions": "^4.1.4",
         "@netlify/vite-plugin": "^2.2.2",
         "@sparticuz/chromium": "^133.0.0",
+        "psl": "^1.15.0",
         "puppeteer": "^24.10.0",
         "puppeteer-core": "^24.10.0",
         "react": "^19.1.0",
@@ -19,6 +20,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@types/psl": "^1.1.3",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
@@ -3287,6 +3289,13 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/psl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/psl/-/psl-1.1.3.tgz",
+      "integrity": "sha512-Iu174JHfLd7i/XkXY6VDrqSlPvTDQOtQI7wNAXKKOAADJ9TduRLkNdMgjGiMxSttUIZnomv81JAbAbC0DhggxA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -8226,6 +8235,18 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@netlify/functions": "^4.1.4",
     "@netlify/vite-plugin": "^2.2.2",
     "@sparticuz/chromium": "^133.0.0",
+    "psl": "^1.15.0",
     "puppeteer": "^24.10.0",
     "puppeteer-core": "^24.10.0",
     "react": "^19.1.0",
@@ -21,6 +22,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@types/psl": "^1.1.3",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",


### PR DESCRIPTION
Changes are meant to make page loading faster (important for SEO and preventing function timeouts), avoiding memory bloat - and forcing "cleanup" (which is often a long operation) before the next invocation of the same function instance.

* Instead of needing a hard-coded list and rules for tracking scripts, etc. - all requests to third-party resources are skipped by default (unless `PRERENDER_SKIP_THIRD_PARTY` is `false`). Requests to subdomains remain intact (but `a.netlify.app` and `b.netlify.app` are considered different domains, out of the box).
* All resource types that typically affect visual rendering only (images, media, css, fonts) are skipped, unless `PRERENDER_SKIP_VISUAL_RESOURCES` is `false`.
* User can still define a custom skip list.

Additionally, a new "dummy" page is created & closed after the synchronous response completes, to force a resource cleanup instead of typically having to hang for precious seconds at the next request.